### PR TITLE
Fix panic when someone send messages start with !

### DIFF
--- a/src/handlers/error.rs
+++ b/src/handlers/error.rs
@@ -181,10 +181,14 @@ async fn handle_error(
             ctx.send(CreateReply::default().content(response).ephemeral(true))
                 .await?;
         }
-        // these two error should be unreachable since we don't use prefix commands
-        // if this really happened it means there's some problem in our code
-        FrameworkError::DynamicPrefix { .. } => unreachable!(),
-        FrameworkError::UnknownCommand { .. } => unreachable!(),
+        // these two error occurs only when someone try to call prefix command
+        // ignore them since we don't use prefix commands
+        FrameworkError::DynamicPrefix { msg, .. } => {
+            tracing::debug!(?msg, "ignore unknonwn command");
+        }
+        FrameworkError::UnknownCommand { msg, .. } => {
+            tracing::debug!(?msg, "ignore unknown command");
+        }
 
         FrameworkError::UnknownInteraction { interaction, .. } => {
             tracing::warn!(?interaction, "received unknown interaction");


### PR DESCRIPTION
serenity/poise parse message as potential command invoke, even we don't have any prefix command registered. So if someone send messages start with `!`, the bot will panic since we were using `unreachable!()` to handle them, this PR fix this.